### PR TITLE
Fix password reset flow: add missing /reset-password route

### DIFF
--- a/openweights/dashboard/frontend/src/App.tsx
+++ b/openweights/dashboard/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import { JobsView } from './components/JobsView';
 import { WorkersView } from './components/WorkersView';
 import { JobDetailView, RunDetailView, WorkerDetailView } from './components/DetailViews';
 import { Auth } from './components/Auth/Auth';
+import { ResetPassword } from './components/Auth/ResetPassword';
 import { OrganizationList } from './components/Organizations/OrganizationList';
 import { OrganizationDetail } from './components/Organizations/OrganizationDetail';
 import { OrganizationSwitcher } from './components/Organizations/OrganizationSwitcher';
@@ -220,6 +221,7 @@ function AppContent() {
                 <Container maxWidth={false} sx={{ mt: 1.5, mb: 1.5, height: 'calc(100vh - 60px)' }}>
                     <Routes>
                         <Route path="/login" element={<Auth />} />
+                        <Route path="/reset-password" element={<ResetPassword />} />
                         <Route path="/organizations" element={
                             <PrivateRoute>
                                 <OrganizationList />

--- a/openweights/dashboard/frontend/src/components/Auth/ResetPassword.tsx
+++ b/openweights/dashboard/frontend/src/components/Auth/ResetPassword.tsx
@@ -1,0 +1,158 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Box,
+  Button,
+  TextField,
+  Typography,
+  Container,
+  Alert,
+} from '@mui/material';
+import { supabase } from '../../supabaseClient';
+
+export function ResetPassword() {
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [sessionReady, setSessionReady] = useState(false);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    // Supabase processes the recovery token from the URL fragment
+    // and fires a PASSWORD_RECOVERY event when ready
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((event) => {
+      if (event === 'PASSWORD_RECOVERY') {
+        setSessionReady(true);
+        setLoading(false);
+      }
+    });
+
+    // Also check if we already have a session (e.g. page was refreshed)
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (session) {
+        setSessionReady(true);
+      }
+      setLoading(false);
+    });
+
+    return () => subscription.unsubscribe();
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+
+    if (password !== confirmPassword) {
+      setError('Passwords do not match');
+      return;
+    }
+
+    if (password.length < 6) {
+      setError('Password must be at least 6 characters');
+      return;
+    }
+
+    try {
+      const { error } = await supabase.auth.updateUser({ password });
+      if (error) throw error;
+      setSuccess('Password updated successfully! Redirecting to login...');
+      setTimeout(() => navigate('/login'), 2000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update password');
+    }
+  };
+
+  if (loading) {
+    return (
+      <Container component="main" maxWidth="xs">
+        <Box sx={{ marginTop: 8, textAlign: 'center' }}>
+          <Typography>Loading...</Typography>
+        </Box>
+      </Container>
+    );
+  }
+
+  if (!sessionReady) {
+    return (
+      <Container component="main" maxWidth="xs">
+        <Box sx={{ marginTop: 8, textAlign: 'center' }}>
+          <Alert severity="error" sx={{ mb: 2 }}>
+            Invalid or expired reset link. Please request a new password reset.
+          </Alert>
+          <Button variant="contained" onClick={() => navigate('/login')}>
+            Back to Login
+          </Button>
+        </Box>
+      </Container>
+    );
+  }
+
+  return (
+    <Container component="main" maxWidth="xs">
+      <Box
+        sx={{
+          marginTop: 8,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+        }}
+      >
+        <Typography component="h1" variant="h5" gutterBottom>
+          Set New Password
+        </Typography>
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 2, width: '100%' }}>
+            {error}
+          </Alert>
+        )}
+
+        {success && (
+          <Alert severity="success" sx={{ mb: 2, width: '100%' }}>
+            {success}
+          </Alert>
+        )}
+
+        <Box component="form" onSubmit={handleSubmit} sx={{ mt: 1, width: '100%' }}>
+          <TextField
+            margin="normal"
+            required
+            fullWidth
+            name="password"
+            label="New Password"
+            type="password"
+            id="password"
+            autoComplete="new-password"
+            autoFocus
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+
+          <TextField
+            margin="normal"
+            required
+            fullWidth
+            name="confirmPassword"
+            label="Confirm New Password"
+            type="password"
+            id="confirmPassword"
+            autoComplete="new-password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+          />
+
+          <Button
+            type="submit"
+            fullWidth
+            variant="contained"
+            sx={{ mt: 3, mb: 2 }}
+          >
+            Update Password
+          </Button>
+        </Box>
+      </Box>
+    </Container>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `ResetPassword` component that handles the Supabase recovery token from the email link and lets users set a new password
- Add `/reset-password` route in `App.tsx` so the redirect URL actually resolves

## Problem
The password reset email was sent correctly, but the link redirected to `/reset-password` which had no route — users hit a 404 or got bounced to login.

## Test plan
- [ ] Request a password reset from the login page
- [ ] Click the link in the email and verify the "Set New Password" form appears
- [ ] Submit a new password and verify redirect to login
- [ ] Verify expired/invalid links show an appropriate error message

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)