### PR TITLE
fix: pick first allowed_hardware instead of random choice

### DIFF
--- a/openweights/cluster/org_manager.py
+++ b/openweights/cluster/org_manager.py
@@ -52,9 +52,11 @@ def determine_gpu_type(required_vram, allowed_hardware=None):
     """
     vram_options = sorted(HARDWARE_CONFIG.keys())
 
-    # If allowed_hardware is specified, filter GPU options to only include allowed configurations
+    # If allowed_hardware is specified, try the first option (cheapest).
+    # On failure the caller removes the failed entry, so next cycle
+    # naturally falls through to the next preference.
     if allowed_hardware:
-        hardware_config = random.choice(allowed_hardware)
+        hardware_config = allowed_hardware[0]
         count, gpu = hardware_config.split("x ")
         return gpu.strip(), int(count)
 

--- a/tests/test_first_tried_gpu_allocation.py
+++ b/tests/test_first_tried_gpu_allocation.py
@@ -1,0 +1,106 @@
+"""Tests for deterministic GPU allocation (first entry in allowed_hardware).
+
+We load `determine_gpu_type` directly from the source file to avoid pulling
+in the full openweights package (which needs DB credentials and has
+import-time side effects).
+"""
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Load org_manager.py in isolation by stubbing its heavy dependencies.
+# ---------------------------------------------------------------------------
+ROOT = Path(__file__).resolve().parent.parent
+
+# Stub modules that org_manager imports at the top level
+_stubs = {}
+for mod_name in [
+    "openweights",
+    "openweights.client",
+    "openweights.client.decorators",
+    "openweights.cluster",
+    "openweights.cluster.start_runpod",
+    "requests",
+    "runpod",
+    "dotenv",
+]:
+    _stubs[mod_name] = sys.modules.get(mod_name, None)
+    sys.modules[mod_name] = MagicMock()
+
+# Make supabase_retry a passthrough decorator
+sys.modules["openweights.client.decorators"].supabase_retry = lambda *a, **kw: (lambda f: f)
+
+# Provide a real dict for HARDWARE_CONFIG so sorted() works on it
+MOCK_HARDWARE_CONFIG = {
+    43: ["1x L40"],       # 48 GB - 5
+    75: ["1x A100"],      # 80 GB - 5
+    136: ["1x H200"],     # 141 GB - 5
+}
+sys.modules["openweights.cluster.start_runpod"].HARDWARE_CONFIG = MOCK_HARDWARE_CONFIG
+sys.modules["openweights.cluster.start_runpod"].populate_hardware_config = MagicMock()
+
+# Now import the module under test
+spec = importlib.util.spec_from_file_location(
+    "org_manager",
+    ROOT / "openweights" / "cluster" / "org_manager.py",
+)
+org_manager = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(org_manager)
+
+determine_gpu_type = org_manager.determine_gpu_type
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestDetermineGpuType:
+    """Tests for determine_gpu_type with allowed_hardware."""
+
+    def test_picks_first_entry(self):
+        """Should always pick the first entry, not a random one."""
+        gpu, count = determine_gpu_type(0, allowed_hardware=["1x L40", "1x A100", "1x H200"])
+        assert gpu == "L40"
+        assert count == 1
+
+    def test_picks_first_entry_deterministic(self):
+        """Running 50 times should always return the same result (not random)."""
+        allowed = ["1x L40", "1x A100", "1x H200"]
+        results = [determine_gpu_type(0, allowed_hardware=allowed) for _ in range(50)]
+        assert all(r == ("L40", 1) for r in results)
+
+    def test_respects_order_a100_first(self):
+        """If A100 is listed first, it should be selected."""
+        gpu, count = determine_gpu_type(0, allowed_hardware=["1x A100", "1x L40"])
+        assert gpu == "A100"
+        assert count == 1
+
+    def test_multi_gpu_config(self):
+        """Should parse multi-GPU entries correctly."""
+        gpu, count = determine_gpu_type(0, allowed_hardware=["2x A100", "1x H200"])
+        assert gpu == "A100"
+        assert count == 2
+
+    def test_single_entry_list(self):
+        """Single-entry list should work fine."""
+        gpu, count = determine_gpu_type(0, allowed_hardware=["1x H200"])
+        assert gpu == "H200"
+        assert count == 1
+
+    def test_no_allowed_hardware_falls_through(self):
+        """When allowed_hardware is None, should fall through to VRAM-based logic."""
+        gpu, count = determine_gpu_type(40, allowed_hardware=None)
+        assert gpu == "L40"
+        assert count == 1
+
+    def test_empty_list_falls_through(self):
+        """When allowed_hardware is an empty list, should fall through to VRAM-based logic."""
+        gpu, count = determine_gpu_type(40, allowed_hardware=[])
+        assert gpu == "L40"
+        assert count == 1

--- a/tests/test_first_tried_gpu_allocation.py
+++ b/tests/test_first_tried_gpu_allocation.py
@@ -6,7 +6,6 @@ import-time side effects).
 """
 
 import importlib.util
-import os
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -69,38 +68,14 @@ class TestDetermineGpuType:
         assert gpu == "L40"
         assert count == 1
 
-    def test_picks_first_entry_deterministic(self):
-        """Running 50 times should always return the same result (not random)."""
-        allowed = ["1x L40", "1x A100", "1x H200"]
-        results = [determine_gpu_type(0, allowed_hardware=allowed) for _ in range(50)]
-        assert all(r == ("L40", 1) for r in results)
-
-    def test_respects_order_a100_first(self):
-        """If A100 is listed first, it should be selected."""
-        gpu, count = determine_gpu_type(0, allowed_hardware=["1x A100", "1x L40"])
-        assert gpu == "A100"
-        assert count == 1
-
     def test_multi_gpu_config(self):
         """Should parse multi-GPU entries correctly."""
         gpu, count = determine_gpu_type(0, allowed_hardware=["2x A100", "1x H200"])
         assert gpu == "A100"
         assert count == 2
 
-    def test_single_entry_list(self):
-        """Single-entry list should work fine."""
-        gpu, count = determine_gpu_type(0, allowed_hardware=["1x H200"])
-        assert gpu == "H200"
-        assert count == 1
-
     def test_no_allowed_hardware_falls_through(self):
         """When allowed_hardware is None, should fall through to VRAM-based logic."""
         gpu, count = determine_gpu_type(40, allowed_hardware=None)
-        assert gpu == "L40"
-        assert count == 1
-
-    def test_empty_list_falls_through(self):
-        """When allowed_hardware is an empty list, should fall through to VRAM-based logic."""
-        gpu, count = determine_gpu_type(40, allowed_hardware=[])
         assert gpu == "L40"
         assert count == 1


### PR DESCRIPTION
## Summary
- When `allowed_hardware` is specified, `determine_gpu_type` now picks the first entry (expected to be cheapest) instead of `random.choice()`
- This makes GPU selection deterministic and cost-optimal — the caller orders the list by preference, and on failure the scheduler removes the failed entry so the next cycle naturally falls through to the next option

## Test plan
- [ ] Verify that jobs with `allowed_hardware=["1x L40", "1x A100"]` consistently start on an L40 first
- [ ] Confirm that if the first GPU type fails to provision, the next option is tried on the following scheduling cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)