### PR TITLE
feat: add cloud_type parameter for on-demand vs spot GPU selection

### DIFF
--- a/openweights/cli/exec.py
+++ b/openweights/cli/exec.py
@@ -23,6 +23,12 @@ def add_exec_parser(parser):
         help="Allowed hardware configurations (e.g., '2x A100'). Can be specified multiple times.",
     )
     parser.add_argument(
+        "--cloud-type",
+        default="SECURE",
+        choices=["ALL", "SECURE", "COMMUNITY"],
+        help="RunPod cloud provider type: SECURE (on-demand, default), ALL, or COMMUNITY (spot).",
+    )
+    parser.add_argument(
         "--wait",
         action="store_true",
         help="Wait for job completion and stream logs.",
@@ -51,6 +57,8 @@ def handle_exec(args) -> int:
     job_params = {"command": args.command}
     if args.allowed_hardware:
         job_params["allowed_hardware"] = args.allowed_hardware
+    if args.cloud_type:
+        job_params["cloud_type"] = args.cloud_type
 
     print(f"[ow] Submitting job: {args.command}")
     job = exec_job.create(**job_params)

--- a/openweights/client/jobs.py
+++ b/openweights/client/jobs.py
@@ -300,12 +300,14 @@ class Jobs:
         Args:
             **params: Parameters for the job, will be validated against self.params
             allowed_hardware: Optional list of allowed hardware configurations (e.g. ['2x A100', '4x H100'])
+            cloud_type: RunPod cloud provider type: 'SECURE' (on-demand, default), 'ALL', or 'COMMUNITY' (spot)
 
         Returns:
             The created job object
         """
-        # Extract allowed_hardware if provided
+        # Extract allowed_hardware and cloud_type if provided
         allowed_hardware = params.pop("allowed_hardware", None)
+        cloud_type = params.pop("cloud_type", "SECURE")
 
         # Validate parameters
         validated_params = self.params(**params)
@@ -325,6 +327,7 @@ class Jobs:
             "params": {
                 "validated_params": validated_params.model_dump(),
                 "mounted_files": mounted_files,
+                "cloud_type": cloud_type,
             },
         }
 

--- a/openweights/cluster/org_manager.py
+++ b/openweights/cluster/org_manager.py
@@ -350,17 +350,25 @@ class OrganizationManager:
                 ).execute()
 
     def group_jobs_by_hardware_requirements(self, pending_jobs):
-        """Group jobs by their hardware requirements."""
+        """Group jobs by their hardware requirements and cloud type.
+
+        Jobs with different cloud_type values get separate workers so each
+        worker is launched on the correct RunPod cloud tier.
+        """
         job_groups = {}
 
         for job in pending_jobs:
-            # Create a key based on allowed_hardware
+            cloud_type = (job.get("params") or {}).get("cloud_type") or "SECURE"
+
+            # Create a key based on (cloud_type, allowed_hardware)
             if job["allowed_hardware"]:
                 # Sort the allowed hardware to ensure consistent grouping
-                key = tuple(sorted(job["allowed_hardware"]))
+                hw_key = tuple(sorted(job["allowed_hardware"]))
             else:
                 # Jobs with no hardware requirements can run on any hardware
-                key = None
+                hw_key = None
+
+            key = (cloud_type, hw_key)
 
             if key not in job_groups:
                 job_groups[key] = []
@@ -412,7 +420,7 @@ class OrganizationManager:
                 )
 
                 # Process each hardware group separately
-                for hardware_key, hardware_jobs in job_groups.items():
+                for (cloud_type, hardware_key), hardware_jobs in job_groups.items():
                     # Calculate how many workers to start for this hardware group
                     group_num_to_start = min(
                         len(hardware_jobs) - starting_count, available_slots
@@ -483,6 +491,7 @@ class OrganizationManager:
                                     env=self.worker_env,
                                     name=f"{self._ow.org_name}-{time.time()}-ow-1day",
                                     runpod_client=runpod,
+                                    cloud_type=cloud_type,
                                 )
                                 # Update worker with pod_id
                                 assert pod is not None

--- a/openweights/cluster/start_runpod.py
+++ b/openweights/cluster/start_runpod.py
@@ -285,6 +285,7 @@ def _start_worker(
     pending_workers=None,
     env=None,
     runpod_client=None,
+    cloud_type="SECURE",
 ):
     client = runpod_client or runpod
     gpu = GPUs[gpu]
@@ -319,6 +320,7 @@ def _start_worker(
         ports="8000/http,10101/http,22/tcp",
         start_ssh=True,
         env=env,
+        cloud_type=cloud_type,
     )
     pending_workers.append(pod["id"])
 
@@ -341,6 +343,7 @@ def start_worker(
     ttl_hours=24,
     env=None,
     runpod_client=None,
+    cloud_type="SECURE",
 ):
     pending_workers = []
     if dev_mode:
@@ -371,6 +374,7 @@ def start_worker(
             pending_workers,
             env,
             runpod_client,
+            cloud_type,
         )
         return pod
     except Exception as e:

--- a/openweights/jobs/inference/__init__.py
+++ b/openweights/jobs/inference/__init__.py
@@ -38,7 +38,7 @@ class InferenceJobs(Jobs, OpenAIInferenceSupport):
         return self.get_or_create_or_reset(data)
 
     def create(
-        self, requires_vram_gb="guess", allowed_hardware=None, **params
+        self, requires_vram_gb="guess", allowed_hardware=None, cloud_type="SECURE", **params
     ) -> Dict[str, Any]:
         """Create an inference job"""
         InferenceConfig(**params)
@@ -76,6 +76,7 @@ class InferenceJobs(Jobs, OpenAIInferenceSupport):
             "params": {
                 "validated_params": {**params, "input_file_id": input_file_id},
                 "mounted_files": self._upload_mounted_files(),
+                "cloud_type": cloud_type,
             },
             "status": "pending",
             "requires_vram_gb": requires_vram_gb,

--- a/openweights/jobs/unsloth/__init__.py
+++ b/openweights/jobs/unsloth/__init__.py
@@ -27,7 +27,7 @@ class FineTuning(Jobs):
 
     @supabase_retry()
     def create(
-        self, requires_vram_gb=24, allowed_hardware=None, **params
+        self, requires_vram_gb=24, allowed_hardware=None, cloud_type="SECURE", **params
     ) -> Dict[str, Any]:
         """Create a fine-tuning job"""
         if "training_file" not in params:
@@ -66,7 +66,7 @@ class FineTuning(Jobs):
             "id": job_id,
             "type": "fine-tuning",
             "model": params["model"],
-            "params": {"validated_params": params, "mounted_files": mounted_files},
+            "params": {"validated_params": params, "mounted_files": mounted_files, "cloud_type": cloud_type},
             "status": "pending",
             "requires_vram_gb": requires_vram_gb,
             "allowed_hardware": allowed_hardware,
@@ -98,7 +98,7 @@ class LogProb(Jobs):
 
     @supabase_retry()
     def create(
-        self, requires_vram_gb="guess", allowed_hardware=None, **params
+        self, requires_vram_gb="guess", allowed_hardware=None, cloud_type="SECURE", **params
     ) -> Dict[str, Any]:
         """Create a logprob evaluation job"""
         if requires_vram_gb == "guess":
@@ -113,7 +113,7 @@ class LogProb(Jobs):
             "id": job_id,
             "type": "custom",
             "model": params["model"],
-            "params": {"params": params, "mounted_files": mounted_files},
+            "params": {"params": params, "mounted_files": mounted_files, "cloud_type": cloud_type},
             "status": "pending",
             "requires_vram_gb": requires_vram_gb,
             "allowed_hardware": allowed_hardware,

--- a/openweights/jobs/vllm/__init__.py
+++ b/openweights/jobs/vllm/__init__.py
@@ -27,7 +27,7 @@ class API(Jobs):
         on_backoff=lambda details: print(f"Retrying... {details['exception']}"),
     )
     def create(
-        self, requires_vram_gb="guess", allowed_hardware=None, **params
+        self, requires_vram_gb="guess", allowed_hardware=None, cloud_type="SECURE", **params
     ) -> Dict[str, Any]:
         """Create an inference job"""
         params = ApiConfig(**params).model_dump()
@@ -92,7 +92,7 @@ class API(Jobs):
             "id": job_id,
             "type": "api",
             "model": model,
-            "params": params,
+            "params": {**params, "cloud_type": cloud_type},
             "status": "pending",
             "requires_vram_gb": requires_vram_gb,
             "allowed_hardware": allowed_hardware,
@@ -112,6 +112,7 @@ class API(Jobs):
         quantization: Optional[str] = None,
         kv_cache_dtype: Optional[str] = None,
         allowed_hardware=None,
+        cloud_type="SECURE",
     ) -> TemporaryApi:
         """Deploy a model on OpenWeights"""
         if lora_adapters is None:
@@ -130,6 +131,7 @@ class API(Jobs):
             quantization=quantization,
             kv_cache_dtype=kv_cache_dtype,
             allowed_hardware=allowed_hardware,
+            cloud_type=cloud_type,
         )
         return TemporaryApi(self._ow, job["id"])
 
@@ -143,6 +145,7 @@ class API(Jobs):
         quantization: Optional[str] = None,
         kv_cache_dtype: Optional[str] = None,
         allowed_hardware=None,
+        cloud_type="SECURE",
     ) -> Dict[str, TemporaryApi]:
         """Deploy multiple models - creates on server for each base model, and deploys all lora adapters on of the same base model together"""
         assert isinstance(models, list), "models must be a list"
@@ -161,6 +164,7 @@ class API(Jobs):
                 quantization=quantization,
                 kv_cache_dtype=kv_cache_dtype,
                 allowed_hardware=allowed_hardware,
+                cloud_type=cloud_type,
             )
             for model_id in [model] + lora_adapters:
                 apis[model_id] = api

--- a/openweights/jobs/weighted_sft/__init__.py
+++ b/openweights/jobs/weighted_sft/__init__.py
@@ -28,7 +28,7 @@ class SFT(Jobs):
 
     @supabase_retry()
     def create(
-        self, requires_vram_gb="guess", allowed_hardware=None, **params
+        self, requires_vram_gb="guess", allowed_hardware=None, cloud_type="SECURE", **params
     ) -> Dict[str, Any]:
         """Create a fine-tuning job"""
         if "training_file" not in params:
@@ -65,7 +65,7 @@ class SFT(Jobs):
             "id": job_id,
             "type": "fine-tuning",
             "model": params["model"],
-            "params": {"validated_params": params, "mounted_files": mounted_files},
+            "params": {"validated_params": params, "mounted_files": mounted_files, "cloud_type": cloud_type},
             "status": "pending",
             "requires_vram_gb": requires_vram_gb,
             "allowed_hardware": allowed_hardware,
@@ -98,7 +98,7 @@ class MultipleChoice(Jobs):
 
     @supabase_retry()
     def create(
-        self, requires_vram_gb="guess", allowed_hardware=None, **params
+        self, requires_vram_gb="guess", allowed_hardware=None, cloud_type="SECURE", **params
     ) -> Dict[str, Any]:
         """Create a multiple choice evaluation job"""
         if "model" not in params:
@@ -118,7 +118,7 @@ class MultipleChoice(Jobs):
             "id": job_id,
             "type": "custom",
             "model": params["model"],
-            "params": {"validated_params": params, "mounted_files": mounted_files},
+            "params": {"validated_params": params, "mounted_files": mounted_files, "cloud_type": cloud_type},
             "requires_vram_gb": requires_vram_gb,
             "allowed_hardware": allowed_hardware,
             "docker_image": self.base_image,
@@ -141,7 +141,7 @@ class LogProb(Jobs):
 
     @supabase_retry()
     def create(
-        self, requires_vram_gb="guess", allowed_hardware=None, **params
+        self, requires_vram_gb="guess", allowed_hardware=None, cloud_type="SECURE", **params
     ) -> Dict[str, Any]:
         """Create a logprob evaluation job"""
         if requires_vram_gb == "guess":
@@ -156,7 +156,7 @@ class LogProb(Jobs):
             "id": job_id,
             "type": "custom",
             "model": params["model"],
-            "params": {"params": params, "mounted_files": mounted_files},
+            "params": {"params": params, "mounted_files": mounted_files, "cloud_type": cloud_type},
             "status": "pending",
             "requires_vram_gb": requires_vram_gb,
             "allowed_hardware": allowed_hardware,

--- a/tests/test_support_cloud_types.py
+++ b/tests/test_support_cloud_types.py
@@ -1,0 +1,209 @@
+"""Tests for cloud_type support.
+
+Verifies that:
+- Jobs are grouped by (cloud_type, allowed_hardware)
+- cloud_type defaults to "SECURE" when absent from params
+- Different cloud_type values produce separate groups
+- The CLI argument parser accepts cloud_type choices
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Load org_manager.py in isolation (same stub approach as other test files).
+# ---------------------------------------------------------------------------
+ROOT = Path(__file__).resolve().parent.parent
+
+_original_modules = {}
+for mod_name in [
+    "openweights",
+    "openweights.client",
+    "openweights.client.decorators",
+    "openweights.cluster",
+    "openweights.cluster.start_runpod",
+    "requests",
+    "runpod",
+    "dotenv",
+]:
+    _original_modules[mod_name] = sys.modules.get(mod_name, None)
+    sys.modules[mod_name] = MagicMock()
+
+sys.modules["openweights.client.decorators"].supabase_retry = lambda *a, **kw: (lambda f: f)
+sys.modules["openweights.cluster.start_runpod"].HARDWARE_CONFIG = {}
+sys.modules["openweights.cluster.start_runpod"].populate_hardware_config = MagicMock()
+
+spec = importlib.util.spec_from_file_location(
+    "org_manager",
+    ROOT / "openweights" / "cluster" / "org_manager.py",
+)
+org_manager = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(org_manager)
+
+OrganizationManager = org_manager.OrganizationManager
+
+
+def _make_job(cloud_type=None, allowed_hardware=None):
+    """Create a minimal fake job dict."""
+    job = {
+        "allowed_hardware": allowed_hardware,
+        "requires_vram_gb": 48,
+        "params": {},
+    }
+    if cloud_type is not None:
+        job["params"]["cloud_type"] = cloud_type
+    return job
+
+
+class TestGroupJobsByCloudType:
+    """Tests for group_jobs_by_hardware_requirements with cloud_type."""
+
+    def _group(self, jobs):
+        """Call the grouping method without a real OrganizationManager instance."""
+        # It's a plain method that only uses `self` for nothing — call unbound.
+        return OrganizationManager.group_jobs_by_hardware_requirements(None, jobs)
+
+    def test_same_cloud_type_same_hardware_grouped(self):
+        """Jobs with same cloud_type and hardware should be in one group."""
+        jobs = [
+            _make_job(cloud_type="SECURE", allowed_hardware=["1x L40"]),
+            _make_job(cloud_type="SECURE", allowed_hardware=["1x L40"]),
+        ]
+        groups = self._group(jobs)
+        assert len(groups) == 1
+        key = list(groups.keys())[0]
+        assert key[0] == "SECURE"
+        assert len(groups[key]) == 2
+
+    def test_different_cloud_type_creates_separate_groups(self):
+        """Jobs with different cloud_type but same hardware should be separate."""
+        jobs = [
+            _make_job(cloud_type="SECURE", allowed_hardware=["1x A100"]),
+            _make_job(cloud_type="COMMUNITY", allowed_hardware=["1x A100"]),
+        ]
+        groups = self._group(jobs)
+        assert len(groups) == 2
+        cloud_types = {k[0] for k in groups.keys()}
+        assert cloud_types == {"SECURE", "COMMUNITY"}
+
+    def test_default_cloud_type_is_secure(self):
+        """Jobs without cloud_type in params should default to SECURE."""
+        jobs = [
+            _make_job(cloud_type=None, allowed_hardware=["1x L40"]),
+        ]
+        groups = self._group(jobs)
+        key = list(groups.keys())[0]
+        assert key[0] == "SECURE"
+
+    def test_missing_params_defaults_to_secure(self):
+        """Jobs with params=None should default to SECURE."""
+        job = {
+            "allowed_hardware": ["1x L40"],
+            "requires_vram_gb": 48,
+            "params": None,
+        }
+        groups = self._group([job])
+        key = list(groups.keys())[0]
+        assert key[0] == "SECURE"
+
+    def test_no_hardware_with_cloud_type(self):
+        """Jobs with no allowed_hardware should still group by cloud_type."""
+        jobs = [
+            _make_job(cloud_type="COMMUNITY", allowed_hardware=None),
+            _make_job(cloud_type="SECURE", allowed_hardware=None),
+        ]
+        groups = self._group(jobs)
+        assert len(groups) == 2
+
+    def test_three_way_split(self):
+        """SECURE, COMMUNITY, ALL should each get their own group."""
+        jobs = [
+            _make_job(cloud_type="SECURE", allowed_hardware=["1x L40"]),
+            _make_job(cloud_type="COMMUNITY", allowed_hardware=["1x L40"]),
+            _make_job(cloud_type="ALL", allowed_hardware=["1x L40"]),
+        ]
+        groups = self._group(jobs)
+        assert len(groups) == 3
+
+    def test_hardware_order_irrelevant_for_grouping(self):
+        """allowed_hardware is sorted, so order shouldn't matter."""
+        jobs = [
+            _make_job(cloud_type="SECURE", allowed_hardware=["1x A100", "1x L40"]),
+            _make_job(cloud_type="SECURE", allowed_hardware=["1x L40", "1x A100"]),
+        ]
+        groups = self._group(jobs)
+        assert len(groups) == 1
+        assert len(list(groups.values())[0]) == 2
+
+
+class TestGroupKeysAreUnpackable:
+    """The scale_workers loop destructures keys as (cloud_type, hardware_key)."""
+
+    def _group(self, jobs):
+        return OrganizationManager.group_jobs_by_hardware_requirements(None, jobs)
+
+    def test_keys_unpack_correctly(self):
+        """Keys should be (cloud_type, hw_tuple) and unpackable."""
+        jobs = [
+            _make_job(cloud_type="SECURE", allowed_hardware=["1x L40"]),
+            _make_job(cloud_type="COMMUNITY", allowed_hardware=None),
+        ]
+        groups = self._group(jobs)
+        for (cloud_type, hardware_key), group_jobs in groups.items():
+            assert isinstance(cloud_type, str)
+            assert hardware_key is None or isinstance(hardware_key, tuple)
+            assert len(group_jobs) > 0
+
+
+class TestCliCloudTypeArg:
+    """Test that the CLI exec parser accepts --cloud-type."""
+
+    def test_parser_accepts_cloud_type(self):
+        """The exec parser should accept --cloud-type with valid choices."""
+        import argparse
+
+        # Re-create the parser logic from exec.py without importing it
+        parser = argparse.ArgumentParser()
+        parser.add_argument("command")
+        parser.add_argument(
+            "--cloud-type",
+            default="SECURE",
+            choices=["ALL", "SECURE", "COMMUNITY"],
+        )
+
+        args = parser.parse_args(["echo test", "--cloud-type", "COMMUNITY"])
+        assert args.cloud_type == "COMMUNITY"
+
+    def test_parser_default_is_secure(self):
+        """Default cloud_type should be SECURE."""
+        import argparse
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument("command")
+        parser.add_argument(
+            "--cloud-type",
+            default="SECURE",
+            choices=["ALL", "SECURE", "COMMUNITY"],
+        )
+
+        args = parser.parse_args(["echo test"])
+        assert args.cloud_type == "SECURE"
+
+    def test_parser_rejects_invalid_choice(self):
+        """Invalid cloud_type should be rejected."""
+        import argparse
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument("command")
+        parser.add_argument(
+            "--cloud-type",
+            default="SECURE",
+            choices=["ALL", "SECURE", "COMMUNITY"],
+        )
+
+        with pytest.raises(SystemExit):
+            parser.parse_args(["echo test", "--cloud-type", "INVALID"])

--- a/tests/test_support_cloud_types.py
+++ b/tests/test_support_cloud_types.py
@@ -4,7 +4,6 @@ Verifies that:
 - Jobs are grouped by (cloud_type, allowed_hardware)
 - cloud_type defaults to "SECURE" when absent from params
 - Different cloud_type values produce separate groups
-- The CLI argument parser accepts cloud_type choices
 """
 
 import importlib.util
@@ -64,7 +63,6 @@ class TestGroupJobsByCloudType:
 
     def _group(self, jobs):
         """Call the grouping method without a real OrganizationManager instance."""
-        # It's a plain method that only uses `self` for nothing — call unbound.
         return OrganizationManager.group_jobs_by_hardware_requirements(None, jobs)
 
     def test_same_cloud_type_same_hardware_grouped(self):
@@ -110,25 +108,6 @@ class TestGroupJobsByCloudType:
         key = list(groups.keys())[0]
         assert key[0] == "SECURE"
 
-    def test_no_hardware_with_cloud_type(self):
-        """Jobs with no allowed_hardware should still group by cloud_type."""
-        jobs = [
-            _make_job(cloud_type="COMMUNITY", allowed_hardware=None),
-            _make_job(cloud_type="SECURE", allowed_hardware=None),
-        ]
-        groups = self._group(jobs)
-        assert len(groups) == 2
-
-    def test_three_way_split(self):
-        """SECURE, COMMUNITY, ALL should each get their own group."""
-        jobs = [
-            _make_job(cloud_type="SECURE", allowed_hardware=["1x L40"]),
-            _make_job(cloud_type="COMMUNITY", allowed_hardware=["1x L40"]),
-            _make_job(cloud_type="ALL", allowed_hardware=["1x L40"]),
-        ]
-        groups = self._group(jobs)
-        assert len(groups) == 3
-
     def test_hardware_order_irrelevant_for_grouping(self):
         """allowed_hardware is sorted, so order shouldn't matter."""
         jobs = [
@@ -138,72 +117,3 @@ class TestGroupJobsByCloudType:
         groups = self._group(jobs)
         assert len(groups) == 1
         assert len(list(groups.values())[0]) == 2
-
-
-class TestGroupKeysAreUnpackable:
-    """The scale_workers loop destructures keys as (cloud_type, hardware_key)."""
-
-    def _group(self, jobs):
-        return OrganizationManager.group_jobs_by_hardware_requirements(None, jobs)
-
-    def test_keys_unpack_correctly(self):
-        """Keys should be (cloud_type, hw_tuple) and unpackable."""
-        jobs = [
-            _make_job(cloud_type="SECURE", allowed_hardware=["1x L40"]),
-            _make_job(cloud_type="COMMUNITY", allowed_hardware=None),
-        ]
-        groups = self._group(jobs)
-        for (cloud_type, hardware_key), group_jobs in groups.items():
-            assert isinstance(cloud_type, str)
-            assert hardware_key is None or isinstance(hardware_key, tuple)
-            assert len(group_jobs) > 0
-
-
-class TestCliCloudTypeArg:
-    """Test that the CLI exec parser accepts --cloud-type."""
-
-    def test_parser_accepts_cloud_type(self):
-        """The exec parser should accept --cloud-type with valid choices."""
-        import argparse
-
-        # Re-create the parser logic from exec.py without importing it
-        parser = argparse.ArgumentParser()
-        parser.add_argument("command")
-        parser.add_argument(
-            "--cloud-type",
-            default="SECURE",
-            choices=["ALL", "SECURE", "COMMUNITY"],
-        )
-
-        args = parser.parse_args(["echo test", "--cloud-type", "COMMUNITY"])
-        assert args.cloud_type == "COMMUNITY"
-
-    def test_parser_default_is_secure(self):
-        """Default cloud_type should be SECURE."""
-        import argparse
-
-        parser = argparse.ArgumentParser()
-        parser.add_argument("command")
-        parser.add_argument(
-            "--cloud-type",
-            default="SECURE",
-            choices=["ALL", "SECURE", "COMMUNITY"],
-        )
-
-        args = parser.parse_args(["echo test"])
-        assert args.cloud_type == "SECURE"
-
-    def test_parser_rejects_invalid_choice(self):
-        """Invalid cloud_type should be rejected."""
-        import argparse
-
-        parser = argparse.ArgumentParser()
-        parser.add_argument("command")
-        parser.add_argument(
-            "--cloud-type",
-            default="SECURE",
-            choices=["ALL", "SECURE", "COMMUNITY"],
-        )
-
-        with pytest.raises(SystemExit):
-            parser.parse_args(["echo test", "--cloud-type", "INVALID"])


### PR DESCRIPTION
## Summary
- Adds a `cloud_type` parameter (`"SECURE"` / `"ALL"` / `"COMMUNITY"`) to control which RunPod cloud tier workers are provisioned on
- Stored in the job's `params` JSONB — no database migration needed
- Defaults to `"SECURE"` (on-demand) for full backward compatibility

## Changes
Threaded through the entire pipeline (8 files):

- `openweights/cli/exec.py` — new `--cloud-type` CLI argument
- `openweights/client/jobs.py` — base `Jobs.create()` extracts and stores `cloud_type` in params
- `openweights/jobs/inference/__init__.py` — `InferenceJobs.create()`
- `openweights/jobs/unsloth/__init__.py` — `FineTuning.create()` + `LogProb.create()`
- `openweights/jobs/vllm/__init__.py` — `API.create()` + `deploy()` + `multi_deploy()`
- `openweights/jobs/weighted_sft/__init__.py` — `SFT.create()` + `MultipleChoice.create()` + `LogProb.create()`
- `openweights/cluster/org_manager.py` — groups jobs by `(cloud_type, allowed_hardware)` so each worker is launched on the correct tier
- `openweights/cluster/start_runpod.py` — passes `cloud_type` to `create_pod()`

## Test plan
- [ ] Submit a job with `cloud_type="COMMUNITY"` — verify RunPod pod is created as a spot instance
- [ ] Submit a job with default (no `cloud_type`) — verify it uses SECURE (on-demand) as before
- [ ] Submit two jobs with different `cloud_type` values and same `allowed_hardware` — verify they get separate workers
- [ ] CLI: `ow exec --cloud-type COMMUNITY "echo test"` — verify argument is passed through

🤖 Generated with [Claude Code](https://claude.com/claude-code)