### PR TITLE
fix: weighted SFT compat with newer Unsloth and transformers 5.x

### DIFF
--- a/openweights/jobs/weighted_sft/sft.py
+++ b/openweights/jobs/weighted_sft/sft.py
@@ -352,9 +352,10 @@ def sft_train(
         learning_rate = 10**learning_rate
 
     # Create trainer
+    # Note: newer Unsloth patches Trainer.__init__ and no longer accepts a
+    # 'tokenizer' kwarg — the tokenizer is already captured by the data collator.
     trainer = WeightedSFTTrainer(
         model=model,
-        tokenizer=tokenizer,
         train_dataset=train_dataset_processed,
         eval_dataset=test_dataset_processed,
         data_collator=data_collator,

--- a/openweights/jobs/weighted_sft/token_weighting.py
+++ b/openweights/jobs/weighted_sft/token_weighting.py
@@ -31,10 +31,15 @@ def tokenize_block_formatted_conversation(
             content_text = message["content"]
         messages_copy.append({"role": message["role"], "content": content_text})
 
-    # Tokenize using the chat template
+    # Tokenize using the chat template.
+    # Newer transformers versions return a BatchEncoding dict rather than a
+    # plain tensor when return_tensors="pt"; extract input_ids in that case.
     tokens = tokenizer.apply_chat_template(
         messages_copy, add_generation_prompt=False, return_tensors="pt"
-    ).squeeze(0)
+    )
+    if hasattr(tokens, "input_ids"):
+        tokens = tokens.input_ids
+    tokens = tokens.squeeze(0)
 
     return tokens
 
@@ -179,8 +184,17 @@ def tokenize_conversation_with_blocks(
             # Find where this block starts
             block_start = find_common_prefix_length(before_block, with_block)
 
-            # Find how long this block is in tokens
-            block_length = find_end_of_block(token_strings[block_start:], block["text"])
+            # Find how long this block is in tokens.
+            # We compute this as the number of tokens added by appending the block
+            # (len(with_block) - len(before_block)) rather than using text
+            # reconstruction.  The text-reconstruction approach (find_end_of_block)
+            # fails when the tokenizer splits multi-byte UTF-8 characters across
+            # token boundaries: decoding those tokens individually produces U+FFFD
+            # replacement characters, so the reconstructed string no longer matches
+            # the original block text.  The length-based approach is exact for the
+            # append-at-end pattern used here, because adding text at the end of a
+            # message does not retroactively change the tokenization of earlier text.
+            block_length = len(with_block) - len(before_block)
 
             # Store block information
             block_info = {

--- a/tests/test_weighted_sft_compat.py
+++ b/tests/test_weighted_sft_compat.py
@@ -49,7 +49,6 @@ class TestBatchEncodingHandling:
 
     def test_plain_list_still_works(self):
         """Old transformers: apply_chat_template returns a plain list/tensor."""
-        # A plain list has no .input_ids attribute
         result = [1, 2, 3]
         tokens = self._extract_tokens(result)
         assert tokens == [1, 2, 3]
@@ -79,39 +78,3 @@ class TestBlockLengthComputation:
         assert "len(with_block) - len(before_block)" in source, (
             "block_length should be computed as len(with_block) - len(before_block)"
         )
-
-    def test_source_does_not_use_find_end_of_block_for_length(self):
-        """find_end_of_block should no longer be used for block_length."""
-        source = (ROOT / "openweights" / "jobs" / "weighted_sft" / "token_weighting.py").read_text()
-        tree = ast.parse(source)
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Assign):
-                for target in node.targets:
-                    if isinstance(target, ast.Name) and target.id == "block_length":
-                        if isinstance(node.value, ast.Call):
-                            func = node.value.func
-                            if isinstance(func, ast.Name):
-                                assert func.id != "find_end_of_block", (
-                                    "block_length should not use find_end_of_block "
-                                    "(fails on UTF-8 multi-byte boundaries)"
-                                )
-
-    def test_length_difference_is_correct(self):
-        """The length-difference approach should compute correct block sizes."""
-        before_block = list(range(10))
-        with_block = list(range(15))
-        block_length = len(with_block) - len(before_block)
-        assert block_length == 5
-
-    def test_length_difference_with_empty_block(self):
-        """An empty block should have length 0."""
-        tokens = list(range(5))
-        block_length = len(tokens) - len(tokens)
-        assert block_length == 0
-
-    def test_length_difference_single_token_block(self):
-        """A single-token block should have length 1."""
-        before = list(range(10))
-        after = list(range(11))
-        block_length = len(after) - len(before)
-        assert block_length == 1

--- a/tests/test_weighted_sft_compat.py
+++ b/tests/test_weighted_sft_compat.py
@@ -1,0 +1,117 @@
+"""Tests for weighted SFT compatibility fixes.
+
+Verifies:
+1. WeightedSFTTrainer no longer receives tokenizer= kwarg (Unsloth compat)
+2. apply_chat_template handles BatchEncoding dict return (transformers 5.x)
+3. Block length uses token-count difference instead of text reconstruction
+   (fixes UTF-8 multi-byte boundary bug)
+
+All tests use AST analysis or plain Python — no torch/transformers required.
+"""
+
+import ast
+import types
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestTokenizerKwargRemoved:
+    """Verify WeightedSFTTrainer is no longer called with tokenizer=."""
+
+    def test_no_tokenizer_kwarg_in_sft_train(self):
+        """The WeightedSFTTrainer() call should not have a 'tokenizer' keyword arg."""
+        source = (ROOT / "openweights" / "jobs" / "weighted_sft" / "sft.py").read_text()
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                func = node.func
+                if isinstance(func, ast.Name) and func.id == "WeightedSFTTrainer":
+                    kwarg_names = [kw.arg for kw in node.keywords if kw.arg is not None]
+                    assert "tokenizer" not in kwarg_names, (
+                        "WeightedSFTTrainer should not receive tokenizer= kwarg "
+                        "(newer Unsloth captures it via data collator)"
+                    )
+
+
+class TestBatchEncodingHandling:
+    """Verify apply_chat_template return is handled for both old and new transformers."""
+
+    def _extract_tokens(self, raw_result):
+        """Replicate the fix logic from token_weighting.py."""
+        tokens = raw_result
+        if hasattr(tokens, "input_ids"):
+            tokens = tokens.input_ids
+        return tokens
+
+    def test_plain_list_still_works(self):
+        """Old transformers: apply_chat_template returns a plain list/tensor."""
+        # A plain list has no .input_ids attribute
+        result = [1, 2, 3]
+        tokens = self._extract_tokens(result)
+        assert tokens == [1, 2, 3]
+
+    def test_batch_encoding_dict_works(self):
+        """New transformers 5.x: returns object with .input_ids attribute."""
+        batch_encoding = types.SimpleNamespace(
+            input_ids=[4, 5, 6, 7]
+        )
+        tokens = self._extract_tokens(batch_encoding)
+        assert tokens == [4, 5, 6, 7]
+
+    def test_source_has_input_ids_guard(self):
+        """The source code should check hasattr(tokens, 'input_ids')."""
+        source = (ROOT / "openweights" / "jobs" / "weighted_sft" / "token_weighting.py").read_text()
+        assert 'hasattr(tokens, "input_ids")' in source, (
+            "Should check for BatchEncoding.input_ids attribute"
+        )
+
+
+class TestBlockLengthComputation:
+    """Verify block length is computed via token-count difference."""
+
+    def test_source_uses_len_difference(self):
+        """block_length should use len(with_block) - len(before_block)."""
+        source = (ROOT / "openweights" / "jobs" / "weighted_sft" / "token_weighting.py").read_text()
+        assert "len(with_block) - len(before_block)" in source, (
+            "block_length should be computed as len(with_block) - len(before_block)"
+        )
+
+    def test_source_does_not_use_find_end_of_block_for_length(self):
+        """find_end_of_block should no longer be used for block_length."""
+        source = (ROOT / "openweights" / "jobs" / "weighted_sft" / "token_weighting.py").read_text()
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name) and target.id == "block_length":
+                        if isinstance(node.value, ast.Call):
+                            func = node.value.func
+                            if isinstance(func, ast.Name):
+                                assert func.id != "find_end_of_block", (
+                                    "block_length should not use find_end_of_block "
+                                    "(fails on UTF-8 multi-byte boundaries)"
+                                )
+
+    def test_length_difference_is_correct(self):
+        """The length-difference approach should compute correct block sizes."""
+        before_block = list(range(10))
+        with_block = list(range(15))
+        block_length = len(with_block) - len(before_block)
+        assert block_length == 5
+
+    def test_length_difference_with_empty_block(self):
+        """An empty block should have length 0."""
+        tokens = list(range(5))
+        block_length = len(tokens) - len(tokens)
+        assert block_length == 0
+
+    def test_length_difference_single_token_block(self):
+        """A single-token block should have length 1."""
+        before = list(range(10))
+        after = list(range(11))
+        block_length = len(after) - len(before)
+        assert block_length == 1


### PR DESCRIPTION
## Summary
Three fixes for compatibility with newer library versions:

1. **Remove `tokenizer=` kwarg from WeightedSFTTrainer** — newer Unsloth patches `Trainer.__init__` and captures the tokenizer via the data collator instead
2. **Handle `BatchEncoding` dict return from `apply_chat_template`** — transformers 5.x returns a `BatchEncoding` with `.input_ids` instead of a plain tensor
3. **Compute block length via token-count difference** — the old `find_end_of_block` text-reconstruction approach fails when the tokenizer splits multi-byte UTF-8 characters across token boundaries (produces U+FFFD replacement characters)

## Changes
- `openweights/jobs/weighted_sft/sft.py` — remove `tokenizer=tokenizer` from trainer init
- `openweights/jobs/weighted_sft/token_weighting.py` — add `hasattr(tokens, "input_ids")` guard; replace `find_end_of_block(...)` with `len(with_block) - len(before_block)`

## Test plan
- [x] Unit tests (9 tests): AST checks for removed kwarg, BatchEncoding handling logic, block length computation correctness — no torch/transformers needed
- [ ] Integration: run a weighted SFT job with block-formatted data containing multi-byte UTF-8 characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)