### PR TITLE
fix: patch is_offline_mode removed in huggingface_hub ≥ 0.21

### DIFF
--- a/openweights/jobs/inference/cli.py
+++ b/openweights/jobs/inference/cli.py
@@ -1,8 +1,16 @@
 import json
 import logging
+import os
 import sys
 import time
 from pathlib import Path
+
+# huggingface_hub ≥ 0.21 removed `is_offline_mode`; older versions of
+# transformers and peft still do `from huggingface_hub import is_offline_mode`.
+# Patch it back in before any library that depends on it is imported.
+import huggingface_hub as _hfhub
+if not hasattr(_hfhub, "is_offline_mode"):
+    _hfhub.is_offline_mode = lambda: bool(os.environ.get("HF_HUB_OFFLINE", ""))
 
 import torch
 from huggingface_hub import snapshot_download


### PR DESCRIPTION
*Summary*

- `huggingface_hub` >= 0.21 removed the `is_offline_mode` function
- Older versions of `transformers` and `peft` still do `from huggingface_hub import is_offline_mode`, causing an `ImportError` when the inference CLI starts on nodes with a newer `huggingface_hub` installed
- Add a one-time compatibility shim at the top of `openweights/jobs/inference/cli.py`, before any dependent library is imported
- The shim replicates the original semantics: returns `True` when `HF_HUB_OFFLINE` is set in the environment, `False` otherwise

*Test plan*

- [ ] Confirm inference jobs succeed on nodes with `huggingface_hub` >= 0.21 installed
- [ ] Confirm no regression on nodes with older `huggingface_hub` (the `hasattr` guard makes the patch a no-op)