### PR TITLE
Sort candidate GPUs cheapest-first instead of alphabetically

### DIFF
--- a/openweights/cluster/start_runpod.py
+++ b/openweights/cluster/start_runpod.py
@@ -123,6 +123,20 @@ VERIFIED_GPUs = {
     # "RTX3080Ti": "NVIDIA GeForce RTX 3080 Ti",
     # "L4": "NVIDIA L4",
 }
+
+# Approximate RunPod on-demand cost per GPU-hour (USD).
+# Used to sort candidate GPUs cheapest-first within the same VRAM tier.
+# GPUs not listed here get a high default cost so they sort last.
+GPU_COST_PER_HOUR: Dict[str, float] = {
+    "L40": 0.99,
+    "A100": 1.39,
+    "A100S": 1.49,
+    "H100S": 2.69,
+    "H100N": 3.07,
+    "H200": 3.59,
+    "B200": 4.99,
+}
+_DEFAULT_GPU_COST = 999.0  # fallback for unlisted GPUs
 GPU_COUNT = 1
 allowed_cuda_versions = ["12.8"]
 HARDWARE_REFRESH_INTERVAL_SECONDS = int(
@@ -160,6 +174,17 @@ HARDWARE_CONFIG = {}
 def parse_hardware_config(hardware_type: str) -> tuple[int, str]:
     count, gpu = hardware_type.split("x ", maxsplit=1)
     return int(count), gpu.strip()
+
+
+def _gpu_cost_sort_key(hardware_type: str) -> float:
+    """Return the approximate $/hr for a hardware type (e.g. '1x L40' or '2x A100').
+
+    Multi-GPU configs scale linearly.  GPUs missing from GPU_COST_PER_HOUR
+    sort last so newly-added GPUs are never silently preferred over known-cheap ones.
+    """
+    count, gpu_name = parse_hardware_config(hardware_type)
+    per_gpu = GPU_COST_PER_HOUR.get(gpu_name, _DEFAULT_GPU_COST)
+    return count * per_gpu
 
 
 @dataclass
@@ -210,7 +235,7 @@ class RunpodHardwareRegistry:
         for memory_gb, hardware_types in discovered_config.items():
             available = [
                 hardware_type
-                for hardware_type in sorted(set(hardware_types))
+                for hardware_type in sorted(set(hardware_types), key=_gpu_cost_sort_key)
                 if not self._is_on_cooldown(hardware_type, now=now)
             ]
             if available:

--- a/tests/test_runpod_hardware_registry.py
+++ b/tests/test_runpod_hardware_registry.py
@@ -42,6 +42,27 @@ def test_refresh_populates_hardware_config_from_runpod_inventory():
     assert client.calls == 1
 
 
+def test_candidates_within_same_vram_tier_sorted_cheapest_first():
+    """GPUs with the same effective VRAM should be ordered by cost, not alphabetically."""
+    fake_time = FakeTime()
+    registry = RunpodHardwareRegistry(now_fn=fake_time.now)
+    # H100N ($3.07) and H100S ($2.69) both report 80 GB → 75 GB effective.
+    # Alphabetical would give [H100N, H100S]; cost-sorted should give [H100S, H100N].
+    client = FakeRunpodClient(
+        [
+            {"id": "NVIDIA H100 NVL", "memoryInGb": 80},          # H100N — $3.07
+            {"id": "NVIDIA H100 80GB HBM3", "memoryInGb": 80},    # H100S — $2.69
+            {"id": "NVIDIA A100 80GB PCIe", "memoryInGb": 80},    # A100  — $1.39
+            {"id": "NVIDIA A100-SXM4-80GB", "memoryInGb": 80},    # A100S — $1.49
+        ]
+    )
+
+    registry.refresh(client, force=True)
+    candidates = registry.get_candidate_hardware(required_vram=40)
+
+    assert candidates == ["1x A100", "1x A100S", "1x H100S", "1x H100N"]
+
+
 def test_registry_cools_down_gpu_after_repeated_failures_and_readds_after_expiry():
     fake_time = FakeTime()
     registry = RunpodHardwareRegistry(


### PR DESCRIPTION
## Summary
- When no `allowed_hardware` is specified, GPUs within the same VRAM tier were sorted alphabetically — this caused more expensive GPUs to be tried first (e.g. H100N at $3.07/hr before H100S at $2.69/hr)
- Adds a `GPU_COST_PER_HOUR` lookup table and uses it as the sort key in `_rebuild_hardware_config`, so candidates are always ordered cheapest-first
- Unknown GPUs sort last (default cost = $999) so newly-added GPUs are never silently preferred over known-cheap ones

## Test plan
- [x] Existing tests pass
- [x] New test `test_candidates_within_same_vram_tier_sorted_cheapest_first` verifies A100 < A100S < H100S < H100N ordering within the 80 GB tier

🤖 Generated with [Claude Code](https://claude.com/claude-code)