### PR TITLE
fix: disable use_cache during unsloth training to recover v0.8.x VRAM

### DIFF
--- a/openweights/jobs/unsloth/training.py
+++ b/openweights/jobs/unsloth/training.py
@@ -8,7 +8,12 @@ from datasets import Dataset
 from sft import sft_train
 from unsloth import FastLanguageModel
 from unsloth.chat_templates import standardize_sharegpt
-from utils import client, load_jsonl, load_model_and_tokenizer
+from utils import (
+    apply_training_runtime_fixes,
+    client,
+    load_jsonl,
+    load_model_and_tokenizer,
+)
 from validate import TrainingConfig
 
 
@@ -80,6 +85,8 @@ def train(training_cfg):
         loftq_config=None,
         use_dora=False,
     )
+    apply_training_runtime_fixes(model, where=f"unsloth/{training_cfg.loss}")
+
     rows = load_jsonl(training_cfg.training_file)
     dataset = create_dataset(rows, training_cfg.loss)
 

--- a/openweights/jobs/unsloth/utils.py
+++ b/openweights/jobs/unsloth/utils.py
@@ -119,6 +119,44 @@ def is_peft_model(model):
     return is_peft
 
 
+def apply_training_runtime_fixes(model, *, where: str = "unsloth") -> None:
+    """Probe and (conditionally) fix model state right before ``trainer.train()``.
+
+    Background: in v0.8.x the SFT path used ``trl.SFTTrainer``, which silently
+    sets ``model.config.use_cache = False`` in its ``__init__``. The v0.9
+    rewrite of the response-only path swapped ``SFTTrainer`` for plain
+    ``transformers.Trainer``, which does not, leaving the KV cache materialised
+    through every training forward and inflating VRAM on large-vocab / long-
+    context models. This helper restores the previous behavior, and prints the
+    relevant model-runtime state so future regressions are easy to spot.
+
+    Args:
+        model: The model passed to the trainer (typically PEFT-wrapped, as
+            returned by ``FastLanguageModel.get_peft_model``).
+        where: Free-form tag included in log lines so probes from concurrent
+            workers / job types can be told apart.
+    """
+    cfg = getattr(model, "config", None)
+    use_cache_before = getattr(cfg, "use_cache", "<no-config>")
+    attn_impl = getattr(cfg, "_attn_implementation", None)
+    grad_ckpt = getattr(model, "is_gradient_checkpointing", None)
+
+    print(
+        f"[VRAM-probe:{where}] use_cache={use_cache_before!r} "
+        f"_attn_implementation={attn_impl!r} "
+        f"is_gradient_checkpointing={grad_ckpt!r}",
+        flush=True,
+    )
+
+    if cfg is not None and use_cache_before is True:
+        cfg.use_cache = False
+        print(
+            f"[VRAM-probe:{where}] flipped model.config.use_cache "
+            f"True -> False (KV cache during training is wasted VRAM)",
+            flush=True,
+        )
+
+
 def load_jsonl(file_id):
     # try seeing if file_id is a path that exists on disk
     if os.path.exists(file_id):


### PR DESCRIPTION
The v0.9 rewrite of the response-only SFT path swapped trl.SFTTrainer for plain transformers.Trainer. SFTTrainer silently sets model.config.use_cache = False in its __init__; plain Trainer does not. Left enabled, the KV cache is materialised through every training forward, inflating VRAM significantly on large-vocab / long-context models (Qwen 3.x, etc.) and breaking jobs that fit comfortably on v0.8.2.

This adds apply_training_runtime_fixes(model) right after get_peft_model in the unsloth training entrypoint. It logs use_cache, _attn_implementation, and is_gradient_checkpointing so future runtime regressions are visible in worker logs, and flips use_cache to False when needed.

The weighted_sft job already disables use_cache explicitly, so no change is required there.