### PR TITLE
Install unison in the worker images so `ow ssh` works at all

### DIFF
--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -63,3 +63,20 @@ docker run --rm --env-file .env -ti nielsrolf/ow-unsloth:$VERSION /bin/bash
 docker run --rm --env-file .env -ti nielsrolf/ow-vllm:$VERSION /bin/bash
 docker run --rm --env-file .env -ti nielsrolf/ow-cluster:$VERSION /bin/bash
 ```
+
+## File sync (unison)
+
+`ow ssh --sync` syncs with [unison](https://github.com/bcpierce00/unison), which has to be
+present at both ends and refuses to talk to a different version of itself. The images therefore
+pin a specific upstream static build rather than taking whatever apt offers:
+
+| | |
+|---|---|
+| version in the images | 2.54.0 (`UNISON_VERSION` build arg) |
+| what clients need | the same 2.54.0 — `brew install unison` currently gives exactly this |
+
+To move it, bump `UNISON_VERSION` and `UNISON_SHA256` in `Dockerfile` and `Dockerfile.vllm`
+together, then rebuild. Checksums are on the
+[release page](https://github.com/bcpierce00/unison/releases). Keep the two images on the same
+version, and prefer whatever Homebrew currently ships, since that is what most clients will
+install.

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,20 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends git openssh-server python3-venv && \
     rm -rf /var/lib/apt/lists/*
 
+# unison, for `ow ssh --sync`, which needs it present at both ends. Pinned to the upstream
+# static build rather than installed from apt: unison refuses to sync between mismatched
+# versions, and the distro package lags what clients install (Homebrew ships 2.54.0, Ubuntu
+# 24.04 apt has 2.53.x, and those two will not talk to each other).
+ARG UNISON_VERSION=2.54.0
+ARG UNISON_SHA256=d279dff18682c909d3ddb0b280ab151229b4798b9399b1d227084da424337d24
+ADD https://github.com/bcpierce00/unison/releases/download/v${UNISON_VERSION}/unison-${UNISON_VERSION}-ubuntu-22.04-x86_64-static.tar.gz /tmp/unison.tar.gz
+RUN echo "${UNISON_SHA256}  /tmp/unison.tar.gz" | sha256sum -c - && \
+    tar -xzf /tmp/unison.tar.gz -C /tmp --strip-components=1 \
+        unison-${UNISON_VERSION}-ubuntu-22.04-x86_64-static/bin && \
+    install -m 0755 /tmp/bin/unison /tmp/bin/unison-fsmonitor /usr/local/bin/ && \
+    rm -rf /tmp/unison.tar.gz /tmp/bin && \
+    unison -version
+
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH=/opt/venv/bin:$PATH
 

--- a/Dockerfile.vllm
+++ b/Dockerfile.vllm
@@ -14,6 +14,20 @@ RUN apt-get update && \
     rm -f /tmp/cuda-keyring.deb && \
     rm -rf /var/lib/apt/lists/*
 
+# unison, for `ow ssh --sync`, which needs it present at both ends. Pinned to the upstream
+# static build rather than installed from apt: unison refuses to sync between mismatched
+# versions, and the distro package lags what clients install (Homebrew ships 2.54.0, Ubuntu
+# 24.04 apt has 2.53.x, and those two will not talk to each other).
+ARG UNISON_VERSION=2.54.0
+ARG UNISON_SHA256=d279dff18682c909d3ddb0b280ab151229b4798b9399b1d227084da424337d24
+ADD https://github.com/bcpierce00/unison/releases/download/v${UNISON_VERSION}/unison-${UNISON_VERSION}-ubuntu-22.04-x86_64-static.tar.gz /tmp/unison.tar.gz
+RUN echo "${UNISON_SHA256}  /tmp/unison.tar.gz" | sha256sum -c - && \
+    tar -xzf /tmp/unison.tar.gz -C /tmp --strip-components=1 \
+        unison-${UNISON_VERSION}-ubuntu-22.04-x86_64-static/bin && \
+    install -m 0755 /tmp/bin/unison /tmp/bin/unison-fsmonitor /usr/local/bin/ && \
+    rm -rf /tmp/unison.tar.gz /tmp/bin && \
+    unison -version
+
 ENV VIRTUAL_ENV=/opt/venv
 ENV CUDA_HOME=/usr/local/cuda
 ENV PATH=/opt/venv/bin:/usr/local/cuda/bin:$PATH


### PR DESCRIPTION
## What's broken

No `ow ssh` command works against any published image:

```
[ow] unison not found on remote. Please install it in your image.
```

`cli/common.py` already documents unison as a requirement at both ends, and checks for it on the
remote, but no image installs it. So this is unreachable for everyone, not just me.

Worth stressing that this is **not only `--sync`**. The check lives in `REMOTE_INIT`, which
`bootstrap_remote` runs in every mode, so plain `ow ssh <command>` dies on it too. I hit it with
`ow ssh --gpu A100S --count 1 whoami` on a freshly provisioned pod.

## What this changes

- Installs unison in `Dockerfile` (unsloth, the `--image` default) and `Dockerfile.vllm`. The
  cluster image is untouched, since nothing syncs into it.
- Pins the upstream static build at 2.54.0 with a sha256, instead of `apt install unison`.
- Documents the version and how to bump it in `DOCKER_README.md`.

**Why pinned and not apt:** unison refuses to sync between mismatched versions, and the two ends
disagree by default. Homebrew ships 2.54.0; Ubuntu 24.04 apt has 2.53.x. So `apt install unison`
would give you images that still can't sync with a stock macOS client, which is the majority of
callers. The static tarball is 2 MB, and `unison -version` at the end of the layer turns a bad
download into a build failure rather than a first-sync failure.

## What you need to do

The code fix is inert until the images are rebuilt, so this PR does nothing on its own:

1. **Merge.**
2. **Decide on the tag.** I deliberately did *not* touch `IMAGE_VERSION` (still `v0.11`). Either
   rebuild `v0.11` in place, or bump to `v0.12` — but if you bump, `openweights/images.py` and the
   pushed images have to land together, or every job points at a tag that doesn't exist yet. Your
   release process, your call.
3. **Build and push both**, per `DOCKER_README.md`:
   ```sh
   VERSION=$(python -c "from openweights.images import IMAGE_VERSION; print(IMAGE_VERSION)")
   docker buildx build --platform linux/amd64 -t nielsrolf/ow-unsloth:$VERSION --push .
   docker buildx build --platform linux/amd64 -f Dockerfile.vllm -t nielsrolf/ow-vllm:$VERSION --push .
   ```
4. **Sanity check**, which should print 2.54.0 twice:
   ```sh
   docker run --rm nielsrolf/ow-unsloth:$VERSION unison -version
   docker run --rm nielsrolf/ow-vllm:$VERSION unison -version
   ```

## Verified / not verified

- Verified: the release asset exists, the sha256 matches, and `tar --strip-components=1 <dir>/bin`
  lands exactly `bin/unison` and `bin/unison-fsmonitor`. The binary is a statically linked x86-64
  ELF, so being built on 22.04 is fine on the 24.04 base.
- Not verified: I have not built the images. No Docker here.

## Unrelated, but noticed

`DOCKER_README.md` claims the unsloth image is built `FROM unsloth/unsloth:latest` and the vLLM one
`FROM vllm/vllm-openai:v0.19.1`. Both Dockerfiles are actually on
`pytorch/pytorch:2.10.0-cuda12.8-cudnn9-runtime`. Not touching it here, but it misled me for a bit.
