### PR TITLE
Stop dev mode from dropping most of `--env-file`

### DIFF
--- a/openweights/cluster/start_runpod.py
+++ b/openweights/cluster/start_runpod.py
@@ -705,7 +705,12 @@ def start_worker(
 ):
     pending_workers = []
     if dev_mode:
-        env = {
+        # Forward the usual credentials from the caller's shell, then let anything the
+        # caller passed explicitly (e.g. `ow ssh --env-file`) win. This used to replace
+        # `env` outright, which silently dropped every var outside this list --
+        # WANDB_API_KEY, WANDB_PROJECT and MAX_JOBS among them -- so `--env-file`
+        # appeared to work while delivering almost nothing to the pod.
+        forwarded = {
             var: os.environ.get(var)
             for var in [
                 "OPENWEIGHTS_API_KEY",
@@ -715,6 +720,8 @@ def start_worker(
                 "HF_ORG",
             ]
         }
+        forwarded.update({k: v for k, v in (env or {}).items() if v is not None})
+        env = forwarded
     if runpod_client is None:
         runpod.api_key = os.getenv("RUNPOD_API_KEY")
         runpod_client = runpod

--- a/tests/test_start_worker_dev_mode_env.py
+++ b/tests/test_start_worker_dev_mode_env.py
@@ -1,0 +1,64 @@
+import pytest
+
+from openweights.cluster import start_runpod
+
+
+class FakeRunpodClient:
+    """Captures what would have been sent to RunPod."""
+
+    def __init__(self):
+        self.create_kwargs = None
+
+    def create_pod(self, *args, **kwargs):
+        self.create_kwargs = kwargs
+        return {"id": "pod-abc123"}
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setattr(
+        start_runpod, "get_ip_and_port", lambda pod_id, client: ("10.0.0.1", 2222)
+    )
+    return FakeRunpodClient()
+
+
+def _start(client, env):
+    start_runpod.start_worker(
+        gpu="A100",
+        image="some-image",
+        count=1,
+        name="test-worker",
+        dev_mode=True,
+        env=env,
+        runpod_client=client,
+    )
+    return client.create_kwargs["env"]
+
+
+def test_dev_mode_forwards_caller_env_to_the_pod(client, monkeypatch):
+    monkeypatch.setenv("OPENWEIGHTS_API_KEY", "ow-key")
+
+    env = _start(client, {"WANDB_PROJECT": "my-project", "MAX_JOBS": "16"})
+
+    # Vars outside the credential list used to be dropped on the floor.
+    assert env["WANDB_PROJECT"] == "my-project"
+    assert env["MAX_JOBS"] == "16"
+    # ...while the credentials from the caller's shell still get forwarded.
+    assert env["OPENWEIGHTS_API_KEY"] == "ow-key"
+
+
+def test_dev_mode_caller_env_beats_the_shell(client, monkeypatch):
+    monkeypatch.setenv("HF_TOKEN", "from-shell")
+
+    env = _start(client, {"HF_TOKEN": "from-env-file"})
+
+    assert env["HF_TOKEN"] == "from-env-file"
+
+
+def test_dev_mode_still_sets_operational_vars(client, monkeypatch):
+    monkeypatch.setenv("RUNPOD_API_KEY", "rp-key")
+
+    env = _start(client, {"WANDB_PROJECT": "my-project"})
+
+    assert env["OW_DEV"] == "true"
+    assert env["TTL_HOURS"] == "24"


### PR DESCRIPTION
`ow ssh --env-file` reads a .env and hands it to the provider, but in dev mode
`start_worker` rebuilt `env` from `os.environ` using a five-var credential list,
replacing whatever the caller passed. Anything outside that list never reached
the pod: `WANDB_API_KEY`, `WANDB_PROJECT` and `MAX_JOBS` all vanished silently,
so `--env-file` looked like it worked while delivering almost nothing.

The credential list still gets forwarded from the caller's shell, but values the
caller passed explicitly now survive and take precedence over the shell.

Tests cover both halves, plus the operational vars set further down so they
don't regress the other way.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
